### PR TITLE
Publish profiles for baby activity skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Alexa OAuth Sample
-This is sample code for Alexa Skill developers to set up an OAuth 2.0 server. 
+# Alexa OAuth Sample with Baby activity skill account linking
+This is sample code for Alexa Skill developers to set up an OAuth 2.0 server.
 An OAuth 2.0 server is required for Skill account linking, which lets you connect user identities across different account systems.
-Reciprocal authorization and client token management are also included to support mutual account linking for calling Alexa APIs outside of Alexa Skills.
+
+Reciprocal authorization and client token management are also included to support mutual account linking for calling Alexa APIs outside of Alexa Skills. *Only for baby activity skills*, Reciprocal authorization endpoint will identify baby activity user profiles based on the bearer access token in the header and sends the profiles to Alexa.
 
 # Description
 ## Supported Grant Types
@@ -18,8 +19,9 @@ and an Alexa specific grant type (for reciprocal account linking):
 ## Endpoints
 * **/oauth/authorize**: The authorization endpoint is the endpoint on the authorization server where the resource owner logs in, and grants authorization to the client application.
 * **/oauth/token**: The token endpoint is the endpoint on the authorization server where the client application exchanges the authorization code, client ID and client secret, for an access token.
-* **/api/reciprocal/authorize**: The reciprocal authorization endpoint will be invoked by Alexa to send a LWA auth code. *(Only required for mutual account linking)*
-
+* **/api/reciprocal/authorize** *(Only required for mutual account linking)*: The reciprocal authorization endpoint will be invoked by Alexa to send a LWA auth code.*(Only required for mutual account linking of baby activity skills)*
+ For baby activity skills, The reciprocal authorization endpoint will build the baby profiles for the user corresponding to access token in the reciprocal authorization request header. The endpoint will request refresh and access tokens using LWA auth code in the request and use it send the baby activity user profiles to Alexa API.
+* **/api/profiles/publish** *(Only for baby activity skills)*: This endpoint can be used to publish baby activity profiles for a user.
 ## OAuth Management Portal
 * **/login**: The portal used for administration of OAuth Clients and Partners, as well as users to manage their approvals to other clients.
 
@@ -39,8 +41,8 @@ public class AuthenticationServiceProvider {
 
 # Server Setup
 To setup your own OAuth server,
-1. Clone the repository from [alexa-oauth-sample](https://github.com/alexa/alexa-oauth-sample). Optionally, you can modify the repository name
-2. ![CreateStack](images/cloudformation-launch-stack.png) with this [template](https://github.com/alexa/alexa-oauth-sample/blob/master/template.json)
+1. Clone the repository from [alexa-oauth-sample](https://github.com/alexa/alexa-oauth-sample). Optionally, you can modify the repository name.
+2. ![CreateStack](images/cloudformation-launch-stack.png) with this [template](https://github.com/alexa/alexa-oauth-sample/blob/master/template.json). Make sure to use the branch that has code to send profiles for baby activity skills. By default, the branch name will be master_account_linking_baby_activity_skills
 3. Add your Domain Certificate and bind it to your load balancer (LB port: 443, Instance port: 80). *(HTTPS is required for Alexa Skill Account Linking)*
 
 ![CreateStack](images/Infrastructure.png)
@@ -72,7 +74,8 @@ To setup your own OAuth server,
    * Scope: OAuth scopes to define the permissions. (This is used for your resource server, leave empty if you do not have one)
    * Domain List: YOUR DOMAIN (e.g. domain.com, www.domain.com)
 
-
+# Reciprocal Authorization Endpoint for Baby Activity Skills
+When user enables baby activity skill, Alexa requires reciprocal authorization endpoint registered in AccountLinking section during skill onboarding to send baby activity user profiles to Alexa. See [account-linking-for-health](https://developer.amazon.com/docs/account-linking/account-linking-for-health.html) for more details.  
 
 # License
 This library is licensed under the [Amazon Software License 1.0](LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/oauth/server/api/PublishProfilesEndpoint.java
+++ b/src/main/java/com/oauth/server/api/PublishProfilesEndpoint.java
@@ -37,9 +37,6 @@ public class PublishProfilesEndpoint {
     public void publishProfiles(final @RequestBody @RequestParam Map<String, String> parameters) {
         String partnerId = parameters.get("partner_id");
         String clientAccessToken = new BearerTokenExtractor().extract(context).getName();
-        if (clientAccessToken == null) {
-            throw new IllegalArgumentException("Bearer Token must be provided.");
-        }
         if (partnerId == null) {
             throw new IllegalArgumentException("PartnerId parameter must be specified.");
         }

--- a/src/main/java/com/oauth/server/api/PublishProfilesEndpoint.java
+++ b/src/main/java/com/oauth/server/api/PublishProfilesEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.api;
+
+import com.oauth.server.babyactivityskills.BabyActivityProfilePublisher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.authentication.BearerTokenExtractor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+/**
+ * RestController to publish baby activity profiles for a user.
+ *
+ */
+@RestController
+public class PublishProfilesEndpoint {
+
+    @Autowired
+    private HttpServletRequest context;
+
+    @Autowired
+    private BabyActivityProfilePublisher babyActivityProfilePublisher;
+
+    /**
+     * Publishes baby profiles for a user to Alexa on behalf of Alexa Partner.
+    */
+    @RequestMapping(value = "/api/profiles/publish", method = RequestMethod.POST)
+    public void publishProfiles(final @RequestBody @RequestParam Map<String, String> parameters) {
+        String partnerId = parameters.get("partner_id");
+        String clientAccessToken = new BearerTokenExtractor().extract(context).getName();
+        if (clientAccessToken == null) {
+            throw new IllegalArgumentException("Bearer Token must be provided.");
+        }
+        if (partnerId == null) {
+            throw new IllegalArgumentException("PartnerId parameter must be specified.");
+        }
+        babyActivityProfilePublisher.publishProfiles(clientAccessToken, partnerId);
+    }
+
+}

--- a/src/main/java/com/oauth/server/api/ReciprocalAuthorizationEndpoint.java
+++ b/src/main/java/com/oauth/server/api/ReciprocalAuthorizationEndpoint.java
@@ -98,6 +98,8 @@ public class ReciprocalAuthorizationEndpoint {
         // profile changes after account linking. Following code publishes the profiles when customer enables the
         // skill and does account linking. To publish profiles outside of account linking, use publish profiles endpoint.
         babyActivityProfilePublisher.publishProfiles(clientAccessToken, partnerId);
+
+        babyActivityProfilePublisher.publishProfilesAsync(clientAccessToken, partnerId);
     }
 
     /**

--- a/src/main/java/com/oauth/server/authentication/PartnerTokenManager.java
+++ b/src/main/java/com/oauth/server/authentication/PartnerTokenManager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.authentication;
+
+import com.oauth.server.dao.DynamoDBPartnerDetailsDAO;
+import com.oauth.server.dao.DynamoDBPartnerTokenDAO;
+import com.oauth.server.dto.OAuthPartner;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeAccessTokenProvider;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+
+/**
+ * Responsible for retrieving/refreshing access token for a partner.
+ */
+public class PartnerTokenManager {
+
+    @Autowired
+    private DynamoDBPartnerTokenDAO partnerTokenService;
+
+    @Autowired
+    private DynamoDBPartnerDetailsDAO partnerDetailsService;
+
+    public OAuth2AccessToken getAccessToken(String userID, String partnerId) {
+        OAuthPartner partner = partnerDetailsService.loadPartnerByPartnerId(partnerId);
+
+        if (partner == null) {
+            throw new InvalidClientException("Invalid partner id: " + partnerId);
+        }
+
+        OAuth2ProtectedResourceDetails resourceDetails = partner.toProtectedResourceDetails();
+
+        OAuth2AccessToken accessToken = partnerTokenService.getAccessToken(resourceDetails,
+                new UserIDAuthenticationToken(userID));
+
+        if (accessToken == null) {
+            throw new OAuth2Exception("No token found for user: " + userID);
+        } else if (accessToken.getExpiresIn() <= NumberUtils.INTEGER_ZERO) {
+            //Token expired, refresh the token.
+            accessToken = refreshClientToken(accessToken, resourceDetails);
+        }
+
+        partnerTokenService.saveAccessToken(resourceDetails, new UserIDAuthenticationToken(userID), accessToken);
+
+        return accessToken;
+    }
+
+    /**
+     * Refresh a client access token.
+     */
+    private OAuth2AccessToken refreshClientToken(final OAuth2AccessToken accessToken,
+                                                 final OAuth2ProtectedResourceDetails resourceDetails) {
+        final AccessTokenRequest AccessTokenRequest = new DefaultAccessTokenRequest();
+
+        final AuthorizationCodeAccessTokenProvider tokenProvider = new AuthorizationCodeAccessTokenProvider();
+        tokenProvider.setStateMandatory(false);
+
+        return tokenProvider.refreshAccessToken(resourceDetails,
+                accessToken.getRefreshToken(), AccessTokenRequest);
+    }
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisher.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisher.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.babyactivityskills;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.oauth.server.authentication.PartnerTokenManager;
+import com.oauth.server.babyactivityskills.model.Capability;
+import com.oauth.server.babyactivityskills.model.Name;
+import com.oauth.server.babyactivityskills.model.Profile;
+import com.oauth.server.babyactivityskills.model.ProfileReport;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Responsible for publishing baby activity profiles for a user on behalf of a partner to Alexa.
+ */
+public class BabyActivityProfilePublisher {
+    private static final Logger log = LoggerFactory.getLogger(BabyActivityProfilePublisher.class);
+
+    private static final String PROFILE_ENDPOINT = "https://api.amazonalexa.com/v1/health/profile";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final Map<String, Set<Profile>> MOCK_BABY_PROFILES = new HashMap<>();
+
+    static {
+        MOCK_BABY_PROFILES.put("user",
+                ImmutableSet.of(
+                        new Profile("user/baby-1",
+                                new Name("Maggie", "Simpson", ImmutableSet.of("Maggie", "Mag")),
+                                ImmutableSet.of(Capability.WEIGHT, Capability.DIAPER_CHANGE, Capability.INFANT_FEEDING, Capability.SLEEP)))
+        );
+
+        MOCK_BABY_PROFILES.put("admin",
+                ImmutableSet.of(new Profile("admin/baby-1",
+                        new Name("James", "Kirk", ImmutableSet.of("jim")),
+                        ImmutableSet.of(Capability.WEIGHT, Capability.DIAPER_CHANGE, Capability.INFANT_FEEDING, Capability.SLEEP)))
+        );
+    }
+
+    private final TokenStore tokenStore;
+
+    private final PartnerTokenManager partnerTokenManager;
+
+    private final HttpClientFactory httpClientFactory;
+
+    public BabyActivityProfilePublisher(final TokenStore tokenStore,
+                                        final PartnerTokenManager partnerTokenManager,
+                                        final HttpClientFactory httpClientFactory) {
+        this.tokenStore = tokenStore;
+        this.partnerTokenManager = partnerTokenManager;
+        this.httpClientFactory = httpClientFactory;
+    }
+
+    /**
+     * Publish profile given a client access token that was provided by sample Oauth Server to access resources
+     * corresponding to a user and partner who has been granted access to call Alexa. The code resolves the
+     * userId corresponding to accessToken, constructs and publishes the profile using partner's LWA access token.
+     * <p>
+     * See: https://developer.amazon.com/docs/health/profiles.html#how-to-send-a-profile-report for more details.
+     *
+     * @param clientAccessToken - AccessToken provided by Oauth Server.
+     * @param partnerId         - Alexa PartnerId
+     */
+    public void publishProfiles(final String clientAccessToken, final String partnerId) {
+        final String userId = getUserFromAccessToken(clientAccessToken);
+        final OAuth2AccessToken lwaAccessToken = partnerTokenManager.getAccessToken(userId, partnerId);
+        publishProfilesForUser(userId, lwaAccessToken);
+    }
+
+    private void publishProfilesForUser(final String userId, final OAuth2AccessToken lwaAccessToken) {
+        final Set<Profile> profiles = MOCK_BABY_PROFILES.get(userId);
+        if (profiles == null) {
+            throw new RuntimeException("No profiles found for user");
+        }
+        final HttpPost postRequest = newPostProfilesRequest(userId, profiles, lwaAccessToken.getValue());
+
+        try (final CloseableHttpClient httpClient = httpClientFactory.createDefault();
+             final CloseableHttpResponse response = httpClient.execute(postRequest)) {
+            log.info("Posted {} profiles for user:{} and received response:{}", profiles.size(), userId, response.getStatusLine());
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new RuntimeException("Failed to publish baby profiles for user. ResponseStatus:" + response.getStatusLine());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to publish baby profiles for user:" + userId, e);
+        }
+    }
+
+    private HttpPost newPostProfilesRequest(final String userId,
+                                           final Set<Profile> profiles, final String lwaAccessToken) {
+        final HttpPost postRequest = new HttpPost(PROFILE_ENDPOINT);
+        postRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + lwaAccessToken);
+        postRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+        try {
+            final ProfileReport profileReport = new ProfileReport(UUID.randomUUID().toString(), profiles);
+            final String requestPayload = MAPPER.writeValueAsString(Collections.singletonMap("report", profileReport));
+            final StringEntity entity = new StringEntity(requestPayload);
+            entity.setContentType(ContentType.APPLICATION_JSON.toString());
+            postRequest.setEntity(entity);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to compose post request to send profiles for user:" + userId);
+        }
+        return postRequest;
+    }
+
+    private String getUserFromAccessToken(final String accessToken) {
+        final OAuth2Authentication authentication = tokenStore.readAuthentication(accessToken);
+        if (authentication == null) {
+            throw new IllegalArgumentException("No resource found for access token.");
+        }
+        return authentication.getName();
+    }
+
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisher.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisher.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Responsible for publishing baby activity profiles for a user on behalf of a partner to Alexa.
@@ -64,12 +66,16 @@ public class BabyActivityProfilePublisher {
 
     private final HttpClientFactory httpClientFactory;
 
+    private final ExecutorService asyncExecutor;
+
     public BabyActivityProfilePublisher(final TokenStore tokenStore,
                                         final PartnerTokenManager partnerTokenManager,
-                                        final HttpClientFactory httpClientFactory) {
+                                        final HttpClientFactory httpClientFactory,
+                                        final ExecutorService asyncExecutor) {
         this.tokenStore = tokenStore;
         this.partnerTokenManager = partnerTokenManager;
         this.httpClientFactory = httpClientFactory;
+        this.asyncExecutor = asyncExecutor;
     }
 
     /**
@@ -87,6 +93,11 @@ public class BabyActivityProfilePublisher {
         final OAuth2AccessToken lwaAccessToken = partnerTokenManager.getAccessToken(userId, partnerId);
         publishProfilesForUser(userId, lwaAccessToken);
     }
+
+    public void publishProfilesAsync(final String clientAccessToken, final String partnerId) {
+        asyncExecutor.execute(() -> publishProfiles(clientAccessToken, partnerId));
+    }
+
 
     private void publishProfilesForUser(final String userId, final OAuth2AccessToken lwaAccessToken) {
         final Set<Profile> profiles = MOCK_BABY_PROFILES.get(userId);

--- a/src/main/java/com/oauth/server/babyactivityskills/HttpClientFactory.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/HttpClientFactory.java
@@ -1,0 +1,15 @@
+package com.oauth.server.babyactivityskills;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Wrapper around HttpClients to enable mocking of
+ * http client in unit tests.
+ */
+public class HttpClientFactory {
+
+    public CloseableHttpClient createDefault() {
+        return HttpClients.createDefault();
+    }
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/model/Capability.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/model/Capability.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.babyactivityskills.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents Alexa Health Capabilities.
+ *
+ * See: https://developer.amazon.com/docs/health/profiles.html , 'Capability details' section for more info.
+ */
+public class Capability {
+
+    // baby activity operations
+    private static final String ADD = "Add";
+    private static final String DELETE = "Delete";
+    private static final String GET = "Get";
+    private static final String START = "Start";
+    private static final String STOP = "Stop";
+    private static final String CANCEL = "Cancel";
+    private static final String PAUSE = "Pause";
+    private static final String RESUME = "Resume";
+    private static final String SWITCH = "Switch";
+
+    // available baby activity skill capabilities
+    public static Capability WEIGHT = newBabyActivityCapability("Weight",
+            ImmutableSet.of(ADD, DELETE, GET));
+    public static Capability SLEEP = newBabyActivityCapability("Sleep",
+            ImmutableSet.of(ADD, DELETE, GET, START, STOP, CANCEL, RESUME, PAUSE));
+    public static Capability DIAPER_CHANGE = newBabyActivityCapability("DiaperChange",
+            ImmutableSet.of(ADD, DELETE, GET));
+    public static Capability INFANT_FEEDING = newBabyActivityCapability("InfantFeeding",
+            ImmutableSet.of(ADD, DELETE, GET, START, STOP, CANCEL, RESUME, PAUSE, SWITCH));
+
+    private static Capability newBabyActivityCapability(final String name, final Set<String> supportedOperations) {
+        return new Capability("Alexa.Health." + name, "AlexaInterface", "1", supportedOperations);
+    }
+
+    @JsonProperty
+    private final String name;
+    @JsonProperty
+    private final String type;
+    @JsonProperty
+    private final String version;
+    @JsonProperty
+    private final Set<String> supportedOperations;
+
+    @JsonCreator
+    public Capability(@JsonProperty("name") String name,
+                      @JsonProperty("type")String type,
+                      @JsonProperty("version")String version,
+                      @JsonProperty("supportedOperations")Set<String> supportedOperations) {
+        this.name = name;
+        this.type = type;
+        this.version = version;
+        this.supportedOperations = supportedOperations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Set<String> getSupportedOperations() {
+        return supportedOperations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Capability that = (Capability) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(supportedOperations, that.supportedOperations);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(name, type, version, supportedOperations);
+    }
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/model/Name.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/model/Name.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.babyactivityskills.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents 'name' object in health profile report.
+ *
+ * See: https://developer.amazon.com/docs/health/profiles.html for more dertails.
+ */
+public class Name {
+    private final String firstName;
+    private final String lastName;
+    private final Set<String> nickNames;
+
+    @JsonCreator
+    public Name( @JsonProperty("firstName") String firstName,
+                 @JsonProperty("lastName")String lastName,
+                 @JsonProperty("nickNames")Set<String> nickNames) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.nickNames = nickNames;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public Set<String> getNickNames() {
+        return nickNames;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Name name = (Name) o;
+        return Objects.equals(firstName, name.firstName) &&
+                Objects.equals(lastName, name.lastName) &&
+                Objects.equals(nickNames, name.nickNames);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(firstName, lastName, nickNames);
+    }
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/model/Profile.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/model/Profile.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.babyactivityskills.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a Health Profile.
+ * <p>
+ * See https://developer.amazon.com/docs/health/profiles.html for more details.
+ */
+public class Profile {
+    private final String profileId;
+    private final Name name;
+    private final Set<Capability> capabilities;
+
+    @JsonCreator
+    public Profile(@JsonProperty("profileId") final String profileId,
+                   @JsonProperty("name") final Name babyName,
+                   @JsonProperty("capabilities") final Set<Capability> capabilities) {
+        this.profileId = profileId;
+        this.name = babyName;
+        this.capabilities = capabilities;
+    }
+
+    public String getProfileId() {
+        return profileId;
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public Set<Capability> getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Profile profile = (Profile) o;
+        return Objects.equals(profileId, profile.profileId) &&
+                Objects.equals(name, profile.name) &&
+                Objects.equals(capabilities, profile.capabilities);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(profileId, name, capabilities);
+    }
+}

--- a/src/main/java/com/oauth/server/babyactivityskills/model/ProfileReport.java
+++ b/src/main/java/com/oauth/server/babyactivityskills/model/ProfileReport.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License
+ * http://aws.amazon.com/asl/
+ */
+package com.oauth.server.babyactivityskills.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a ProfileReport that is sent to Alexa.
+ *
+ * See https://developer.amazon.com/docs/health/profiles.html for more details.
+ */
+public class ProfileReport {
+    private final String messageId;
+    private final Set<Profile> profiles;
+
+    @JsonCreator
+    public ProfileReport(@JsonProperty("messageId")String messageId,
+                         @JsonProperty("profiles")Set<Profile> profiles) {
+        this.messageId = messageId;
+        this.profiles = profiles;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public Set<Profile> getProfiles() {
+        return profiles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProfileReport that = (ProfileReport) o;
+        return Objects.equals(messageId, that.messageId) &&
+                Objects.equals(profiles, that.profiles);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(messageId, profiles);
+    }
+}

--- a/src/main/java/com/oauth/server/configuration/AuthorizationServerConfiguration.java
+++ b/src/main/java/com/oauth/server/configuration/AuthorizationServerConfiguration.java
@@ -6,6 +6,7 @@
 package com.oauth.server.configuration;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.oauth.server.authentication.PartnerTokenManager;
 import com.oauth.server.dao.DynamoDBClientDetailsDAO;
 import com.oauth.server.dao.DynamoDBPartnerTokenDAO;
 import com.oauth.server.dao.DynamoDBTokenDAO;
@@ -91,6 +92,11 @@ public class AuthorizationServerConfiguration extends AuthorizationServerConfigu
     @Bean
     public DynamoDBPartnerTokenDAO dynamoDBPartnerTokenService() {
         return new DynamoDBPartnerTokenDAO(dynamoDBMapper);
+    }
+
+    @Bean
+    public PartnerTokenManager partnerTokenManager() {
+        return new PartnerTokenManager();
     }
 
     @Override

--- a/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
+++ b/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
@@ -1,0 +1,26 @@
+package com.oauth.server.configuration;
+
+import com.oauth.server.authentication.PartnerTokenManager;
+import com.oauth.server.babyactivityskills.BabyActivityProfilePublisher;
+import com.oauth.server.babyactivityskills.HttpClientFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+
+@Configuration
+public class BabyActivitySkillsConfiguration {
+
+    @Autowired
+    private TokenStore tokenStore;
+
+    @Autowired
+    private PartnerTokenManager partnerTokenManager;
+
+
+    @Bean
+    public BabyActivityProfilePublisher babyActivityProfilePublisher() {
+        return new BabyActivityProfilePublisher(tokenStore, partnerTokenManager,
+                new HttpClientFactory());
+    }
+}

--- a/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
+++ b/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
@@ -23,6 +23,6 @@ public class BabyActivitySkillsConfiguration {
     @Bean
     public BabyActivityProfilePublisher babyActivityProfilePublisher() {
         return new BabyActivityProfilePublisher(tokenStore, partnerTokenManager,
-                new HttpClientFactory(), Executors.newSingleThreadExecutor());
+                new HttpClientFactory(), Executors.newCachedThreadPool());
     }
 }

--- a/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
+++ b/src/main/java/com/oauth/server/configuration/BabyActivitySkillsConfiguration.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 
+import java.util.concurrent.Executors;
+
 @Configuration
 public class BabyActivitySkillsConfiguration {
 
@@ -21,6 +23,6 @@ public class BabyActivitySkillsConfiguration {
     @Bean
     public BabyActivityProfilePublisher babyActivityProfilePublisher() {
         return new BabyActivityProfilePublisher(tokenStore, partnerTokenManager,
-                new HttpClientFactory());
+                new HttpClientFactory(), Executors.newSingleThreadExecutor());
     }
 }

--- a/src/test/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisherTest.java
+++ b/src/test/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisherTest.java
@@ -1,0 +1,100 @@
+package com.oauth.server.babyactivityskills;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.oauth.server.authentication.PartnerTokenManager;
+import com.oauth.server.babyactivityskills.model.Capability;
+import com.oauth.server.babyactivityskills.model.Name;
+import com.oauth.server.babyactivityskills.model.Profile;
+import com.oauth.server.babyactivityskills.model.ProfileReport;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BabyActivityProfilePublisherTest {
+    private static final String BEARER_ACCESS_TOKEN = "test-token";
+    private static final String LWA_ACCESS_TOKEN = "lwa-access-token";
+    private static final String USER_ID = "user";
+    private static final String PARTNER_ID = "test-partner";
+    private static final Set<Profile> BABY_PROFILES = ImmutableSet.of(
+            new Profile("user/baby-1",
+                    new Name("Maggie", "Simpson", ImmutableSet.of("Maggie", "Mag")),
+                    ImmutableSet.of(Capability.WEIGHT, Capability.DIAPER_CHANGE, Capability.INFANT_FEEDING, Capability.SLEEP)));
+
+    @Mock
+    private TokenStore mockTokenStore;
+
+    @Mock
+    private PartnerTokenManager mockTokenManager;
+
+    @Mock
+    private HttpClientFactory mockHttpClientFactory;
+
+    @Mock
+    private CloseableHttpClient mockHttpClient;
+
+    private BabyActivityProfilePublisher babyActivityProfilePublisher;
+
+    @Before
+    public void setup() {
+        when(mockHttpClientFactory.createDefault()).thenReturn(mockHttpClient);
+        babyActivityProfilePublisher = new BabyActivityProfilePublisher(mockTokenStore,
+                mockTokenManager, mockHttpClientFactory);
+    }
+
+    @Test
+    public void testPublishProfilesGivenValidClientTokenShouldPostProfiles() throws IOException {
+        final OAuth2Authentication mockUserForBearerToken = mock(OAuth2Authentication.class);
+        when(mockUserForBearerToken.getName()).thenReturn(USER_ID);
+        when(mockTokenStore.readAuthentication(BEARER_ACCESS_TOKEN)).thenReturn(mockUserForBearerToken);
+
+        final OAuth2AccessToken mockLwaAccessToken = mock(OAuth2AccessToken.class);
+        when(mockLwaAccessToken.getValue()).thenReturn(LWA_ACCESS_TOKEN);
+        when(mockTokenManager.getAccessToken(USER_ID, PARTNER_ID)).thenReturn(mockLwaAccessToken);
+
+        final CloseableHttpResponse mockHttpResponse = mock(CloseableHttpResponse.class);
+        final StatusLine mockStatusLine = mock(StatusLine.class);
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
+
+        babyActivityProfilePublisher.publishProfiles(BEARER_ACCESS_TOKEN, PARTNER_ID);
+
+        final ArgumentCaptor<HttpPost> postRequestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+        verify(mockHttpClient).execute(postRequestCaptor.capture());
+
+        final HttpPost actualPostRequest = postRequestCaptor.getValue();
+        final ProfileReport actualProfileReport = getProfileReport(actualPostRequest);
+        assertThat(actualProfileReport.getProfiles()).hasSameElementsAs(BABY_PROFILES);
+    }
+
+    private ProfileReport getProfileReport(final HttpPost postRequest) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, ProfileReport.class);
+        final Map<String, ProfileReport> profileReport = mapper.reader().forType(type).readValue(postRequest.getEntity().getContent());
+        return profileReport.get("report");
+    }
+}

--- a/src/test/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisherTest.java
+++ b/src/test/java/com/oauth/server/babyactivityskills/BabyActivityProfilePublisherTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Matchers.any;
@@ -62,7 +63,7 @@ public class BabyActivityProfilePublisherTest {
     public void setup() {
         when(mockHttpClientFactory.createDefault()).thenReturn(mockHttpClient);
         babyActivityProfilePublisher = new BabyActivityProfilePublisher(mockTokenStore,
-                mockTokenManager, mockHttpClientFactory);
+                mockTokenManager, mockHttpClientFactory, mock(ExecutorService.class));
     }
 
     @Test


### PR DESCRIPTION
1.changes to publish profiles during account linking(when reciprocal endpoint is invoked by Alexa)
2.expose publish profiles endpoint that can be used to publish profiles when profile changes in partner side outside of account linking

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
