### PR TITLE
Update the Elastic Beanstalk Platform Version

### DIFF
--- a/template.json
+++ b/template.json
@@ -26,7 +26,7 @@
     "ElasticBeanstalkPlatform": {
       "Description": "enter the latest Java SE version in https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.javase",
       "Type": "String",
-      "Default": "64bit Amazon Linux 2018.03 v2.9.1 running Java 8"
+      "Default": "64bit Amazon Linux 2018.03 v2.10.3 running Java 8"
     }
   },
   "Resources": {


### PR DESCRIPTION
*Issue #, if available:*
The default value of ElasticBeanstalkPlatform does not exist at present.

*Description of changes:*
Update the value with latest Java SE platform versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
